### PR TITLE
IEF cannot be selected as field widget

### DIFF
--- a/inline_entity_form.module
+++ b/inline_entity_form.module
@@ -38,7 +38,7 @@ function inline_entity_form_get_controller(FieldDefinitionInterface $instance) {
   $field_settings = $field->getSettings();
 
   $form_display = entity_get_form_display($instance->entity_type, $instance->bundle, 'default');
-  $widget_settings = $form_display->getComponent($field->field_name)['settings'];
+  $widget_settings = $form_display->getComponent($field->getName())['settings'];
 
   return \Drupal::service("plugin.manager.inline_entity_form")->createInstance('entity:' . $field_settings['target_type'], $widget_settings);
 


### PR DESCRIPTION
The widget can not be selected in the field widget settings. An ajax error occurs.

`$field->field_name` is a protected property. We need to use the getter function for this. `$field->getName()`
