### PR TITLE
Implement IEF as a form element that could be used anywere

### DIFF
--- a/inline_entity_form.module
+++ b/inline_entity_form.module
@@ -713,36 +713,6 @@ function inline_entity_form_get_element($form, FormStateInterface $form_state) {
 }
 
 /**
- * Creates a new entity of the given type and bundle.
- *
- * @param $entity_type
- *   Entity type.
- * @param $bundle
- *   Bundle.
- * @param $language
- *   (Optional) The language to set, if the entity has a language key.
- */
-function inline_entity_form_create_entity($entity_type, $bundle, $language = NULL) {
-  $entity_info = \Drupal::entityManager()->getDefinition($entity_type);
-  $bundle_key = $entity_info->getKey('bundle');
-  $default_values = array();
-  // If the bundle key exists, it must always be set on an entity.
-  if (!empty($bundle_key)) {
-    $default_values[$bundle_key] = $bundle;
-  }
-
-  /*
-  // Set the language if we have both a language key and a language value.
-  if (isset($language) && !empty($entity_info['entity keys']['language'])) {
-    $language_key = $entity_info['entity keys']['language'];
-    $default_values[$language_key] = $language;
-  }
-  */
-
-  return entity_create($entity_type, $default_values);
-}
-
-/**
  * Themes the table showing existing entity references in the widget.
  *
  * @param $variables

--- a/inline_entity_form.module
+++ b/inline_entity_form.module
@@ -563,7 +563,7 @@ function inline_entity_form_close_form($form, FormStateInterface $form_state) {
  */
 function inline_entity_form_cleanup_form_state($form, FormStateInterface $form_state) {
   $element = inline_entity_form_get_element($form, $form_state);
-  inline_entity_form_cleanup_entity_form_state($element['form'], $form_state);
+  inline_entity_form_cleanup_entity_form_state($element['form']['inline_entity_form'], $form_state);
 }
 
 /**
@@ -639,7 +639,7 @@ function inline_entity_form_close_all_forms($elements, FormStateInterface $form_
 function inline_entity_form_cleanup_row_form_state($form, FormStateInterface $form_state) {
   $element = inline_entity_form_get_element($form, $form_state);
   $delta = $form_state->getTriggeringElement()['#ief_row_delta'];
-  $entity_form = $element['entities'][$delta]['form'];
+  $entity_form = $element['entities'][$delta]['form']['inline_entity_form'];
   inline_entity_form_cleanup_entity_form_state($entity_form, $form_state);
 }
 

--- a/inline_entity_form.module
+++ b/inline_entity_form.module
@@ -29,8 +29,6 @@ function inline_entity_form_get_controller(FieldDefinitionInterface $instance) {
 
   /** @var \Drupal\inline_entity_form\InlineEntityFormHandlerInterface $handler */
   $handler = \Drupal::entityManager()->getHandler($target_type, 'inline entity form');
-  // @TODO - could we dynamically figure out entity type?
-  $handler->setEntityTypeId($target_type);
 
   return $handler;
 }

--- a/src/Element/InlineEntityForm.php
+++ b/src/Element/InlineEntityForm.php
@@ -1,0 +1,155 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\inline_entity_form\Element\InlineEntityForm.
+ */
+
+namespace Drupal\inline_entity_form\Element;
+
+use Drupal\Component\Uuid\UuidInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Render\Element\RenderElement;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides an inline entity form element.
+ *
+ * @RenderElement("inline_entity_form")
+ */
+class InlineEntityForm extends RenderElement implements ContainerFactoryPluginInterface {
+
+  /**
+   * Uuid generator service.
+   *
+   * @var \Drupal\Component\Uuid\UuidInterface
+   */
+  protected $uuid;
+
+  /**
+   * Constructs a Drupal\Component\Plugin\PluginBase object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Component\Uuid\UuidInterface $uuid
+   *   Uuid generator service.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, UuidInterface $uuid) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->uuid = $uuid;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('uuid')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getInfo() {
+    $class = get_class($this);
+    return [
+      '#language' => LanguageInterface::LANGCODE_DEFAULT,
+      '#ief_id' => $this->uuid->generate(),
+      '#entity' => NULL,
+      '#entity_type' => NULL,
+      '#bundle' => NULL,
+      '#op' => 'add',
+      '#process' => [
+        [$class, 'processEntityForm'],
+      ],
+      '#theme_wrappers' => ['container'],
+    ];
+  }
+
+  /**
+   * Uses inline entity form handler to add inline form to the structure.
+   *
+   * @param array $element
+   *   An associative array containing the properties of the element.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   * @param array $complete_form
+   *   The complete form structure.
+   *
+   * @return array
+   *   The processed element.
+   *
+   * @see self::preRenderAjaxForm()
+   */
+  public static function processEntityForm($element, FormStateInterface $form_state, &$complete_form) {
+    if (empty($element['#entity_type']) && !empty($element['#entity']) && $element['#entity'] instanceof EntityInterface) {
+      $element['#entity_type'] = $element['#entity']->entityTypeId();
+    }
+
+    if (empty($element['#bundle']) && !empty($element['#entity']) && $element['#entity'] instanceof EntityInterface) {
+      $element['#bundle'] = $element['#entity']->bundle();
+    }
+
+    // We can't do anything useful if we don't know which entity type/ bundle
+    // we're supposed to operate with.
+    if (empty($element['#entity_type']) || empty($element['#bundle'])) {
+      return;
+    }
+
+    /** @var \Drupal\inline_entity_form\InlineEntityFormHandlerInterface $ief_handler */
+    $ief_handler = \Drupal::entityManager()->getHandler($element['#entity_type'], 'inline entity form');
+
+    // IEF handler is a must. If one was not assigned to this entity type we can
+    // not proceed.
+    if (empty($ief_handler)) {
+      return;
+    }
+
+    // If entity object is not there we're displaying the add form. We need to
+    // create a new entity to be used with it.
+    if (empty($element['#entity'])) {
+      if ($element['#op'] == 'add') {
+        $values = [
+          'langcode' => $element['#language'],
+        ];
+
+        $bundle_key = \Drupal::entityManager()
+          ->getDefinition($element['#entity_type'])
+          ->getKey('bundle');
+
+        if ($bundle_key) {
+          $values[$bundle_key] = $element['#bundle'];
+        }
+
+        $element['#entity'] = \Drupal::entityManager()
+          ->getStorage($element['#entity_type'])
+          ->create($values);
+      }
+      else {
+        // TODO - this structure relies on stuff from field. Fix it.
+        $element['#entity'] = $form_state->get(['inline_entity_form', $element['#ief_id'], 'entity', $element['#ief_row_delta'], 'entity']);
+      }
+    }
+
+    $element += $ief_handler->entityForm($element, $form_state);
+
+    // Used by Field API and controller methods to find the relevant
+    // values in $form_state.
+    // TODO - this structure relies on stuff from field. Fix it.
+    //$element['#parents'] = array_merge($element['#parents'], ['entities', $element['#ief_row_delta'], 'form']);
+
+    return $element;
+  }
+
+}

--- a/src/Element/InlineEntityForm.php
+++ b/src/Element/InlineEntityForm.php
@@ -136,19 +136,9 @@ class InlineEntityForm extends RenderElement implements ContainerFactoryPluginIn
           ->getStorage($element['#entity_type'])
           ->create($values);
       }
-      else {
-        // TODO - this structure relies on stuff from field. Fix it.
-        $element['#entity'] = $form_state->get(['inline_entity_form', $element['#ief_id'], 'entity', $element['#ief_row_delta'], 'entity']);
-      }
     }
 
     $element += $ief_handler->entityForm($element, $form_state);
-
-    // Used by Field API and controller methods to find the relevant
-    // values in $form_state.
-    // TODO - this structure relies on stuff from field. Fix it.
-    //$element['#parents'] = array_merge($element['#parents'], ['entities', $element['#ief_row_delta'], 'form']);
-
     return $element;
   }
 

--- a/src/InlineEntityForm/EntityInlineEntityFormHandler.php
+++ b/src/InlineEntityForm/EntityInlineEntityFormHandler.php
@@ -138,28 +138,7 @@ class EntityInlineEntityFormHandler implements InlineEntityFormHandlerInterface 
   /**
    * {@inheritdoc}
    */
-  public function setEntityTypeId($entity_type_id) {
-    $this->entityTypeId = $entity_type_id;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function entityForm($entity_form, FormStateInterface $form_state) {
-
-    // Assume create form if nothing defined.
-    if (empty($entity_form['#op'])) {
-      $entity_form['#op'] = 'add';
-    }
-
-    if (empty($entity_form['#entity'])) {
-      $entity_form['#entity'] = $this->createEntity($entity_form, $form_state);
-    }
-
-    if ($entity_form['#op'] == 'add') {
-      $entity_form['#title'] = t('Add new @type_singular', array('@type_singular' => $this->labels()['singular']));
-    }
-
     $operation = 'default';
     $controller = $this->entityManager->getFormObject($entity_form['#entity']->getEntityTypeId(), $operation);
     $controller->setEntity($entity_form['#entity']);
@@ -289,40 +268,6 @@ class EntityInlineEntityFormHandler implements InlineEntityFormHandlerInterface 
     $child_form_state->setSubmitHandlers($form_state->getSubmitHandlers());
 
     return $child_form_state;
-  }
-
-  /**
-   * "Creates" entity that is being edited/created in inline form.
-   *
-   * Entity will either be created (when creating) or loaded form form state
-   * (when editing).
-   *
-   * @param $form
-   *   Form structure array.
-   * @param FormStateInterface $form_state
-   *   Form state object.
-   *
-   * @return \Drupal\Core\Entity\EntityInterface
-   *   Created entity object.
-   */
-  protected function createEntity($form, FormStateInterface $form_state) {
-    if ($form['#op'] == 'add') {
-      // Create a new entity that will be passed to the form.
-      $ief_settings = $form_state->get(['inline_entity_form', $form['#ief_id']]);
-      if (!empty($ief_settings['form settings']['bundle'])) {
-        $bundle = $ief_settings['form settings']['bundle'];
-      }
-      elseif (!empty($ief_settings['bundle'])) {
-        $bundle = $ief_settings['bundle'];
-      }
-      else {
-        $bundle = reset($ief_settings['settings']['handler_settings']['target_bundles']);
-      }
-      return inline_entity_form_create_entity($form['#entity_type'], $bundle, $form['#parent_language']);
-    }
-    else {
-      return $form_state->get(['inline_entity_form', $form['#ief_id'], 'entities', $form['#ief_row_delta'], 'entity']);
-    }
   }
 
 }

--- a/src/InlineEntityForm/EntityInlineEntityFormHandler.php
+++ b/src/InlineEntityForm/EntityInlineEntityFormHandler.php
@@ -29,7 +29,7 @@ class EntityInlineEntityFormHandler implements InlineEntityFormHandlerInterface 
   protected $entityManager;
 
   /**
-   * ID of entity type managed by this handler
+   * ID of entity type managed by this handler.
    *
    * @var string
    */
@@ -55,10 +55,13 @@ class EntityInlineEntityFormHandler implements InlineEntityFormHandlerInterface 
    *   Entity manager service.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   Module handler service.
+   * @param string $entity_type_id
+   *   ID of entity type managed by this handler.
    */
-  public function __construct(EntityManagerInterface $entity_manager, ModuleHandlerInterface $module_handler) {
+  public function __construct(EntityManagerInterface $entity_manager, ModuleHandlerInterface $module_handler, $entity_type_id) {
     $this->entityManager = $entity_manager;
     $this->moduleHandler = $module_handler;
+    $this->entityTypeId = $entity_type_id;
   }
 
   /**
@@ -67,7 +70,8 @@ class EntityInlineEntityFormHandler implements InlineEntityFormHandlerInterface 
   public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
     return new static(
       $container->get('entity.manager'),
-      $container->get('module_handler')
+      $container->get('module_handler'),
+      $entity_type->id()
     );
   }
 

--- a/src/InlineEntityFormHandlerInterface.php
+++ b/src/InlineEntityFormHandlerInterface.php
@@ -78,14 +78,6 @@ interface InlineEntityFormHandlerInterface extends EntityHandlerInterface {
   public function entityTypeId();
 
   /**
-   * Sets the id of entity type managed by this handler.
-   *
-   * @param string $entity_type_id
-   *   The entity type id..
-   */
-  public function setEntityTypeId($entity_type_id);
-
-  /**
    * Returns the entity form to be shown through the IEF widget.
    *
    * When adding data to $form_state it should be noted that there can be

--- a/src/Plugin/Field/FieldWidget/InlineEntityFormMultiple.php
+++ b/src/Plugin/Field/FieldWidget/InlineEntityFormMultiple.php
@@ -532,7 +532,7 @@ class InlineEntityFormMultiple extends WidgetBase {
         }
       }
       elseif ($form_state->get('inline_entity_form')[$this->getIefId()]['form'] == 'ief_add_existing') {
-        // TODO - needs to be fixed.
+        // TODO - autocomplete seems to be broken and needs to be fixed.
         $element['form'] = array(
           '#type' => 'fieldset',
           '#attributes' => array('class' => array('ief-form', 'ief-form-bottom')),

--- a/src/Plugin/Field/FieldWidget/InlineEntityFormMultiple.php
+++ b/src/Plugin/Field/FieldWidget/InlineEntityFormMultiple.php
@@ -499,6 +499,10 @@ class InlineEntityFormMultiple extends WidgetBase {
             '#entity_type' => $settings['target_type'],
             '#bundle' => $this->determineBundle($form_state),
             '#language' => $parent_langcode,
+            // Labels could be overridden in field widget settings. We won't have
+            // access to those in static callbacks (#process, ...) so let's add
+            // them here.
+            '#ief_labels' => $this->labels(),
             // Identifies the IEF widget to which the form belongs.
             '#ief_id' => $this->getIefId(),
             // Used by Field API and controller methods to find the relevant
@@ -664,17 +668,14 @@ class InlineEntityFormMultiple extends WidgetBase {
    *   Form array structure.
    */
   public static function buildEntityFormActions($element) {
-    // TODO Use overrides.
-    $labels =  \Drupal::entityManager()->getHandler($element['#entity_type'], 'inline entity form')->labels();
-
     // Build a delta suffix that's appended to button #name keys for uniqueness.
     $delta = $element['#ief_id'];
     if ($element['#op'] == 'add') {
-      $save_label = t('Create @type_singular', ['@type_singular' => $labels['singular']]);
+      $save_label = t('Create @type_singular', ['@type_singular' => $element['#ief_labels']['singular']]);
     }
     else {
       $delta .= '-' . $element['#ief_row_delta'];
-      $save_label = t('Update @type_singular', ['@type_singular' => $labels['singular']]);
+      $save_label = t('Update @type_singular', ['@type_singular' => $element['#ief_labels']['singular']]);
     }
 
     // Add action submit elements.


### PR DESCRIPTION
This converts IEF to a "real" form element (<code>'#type' => 'inline_entity_form'</code>). I didn't test it in a custom form yet, it is only a conversion that preserves current functionality. That will be next step (and different PR). 
