### PR TITLE
Replace deprecated functions

### DIFF
--- a/inline_entity_form.module
+++ b/inline_entity_form.module
@@ -12,6 +12,8 @@ use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
+use Drupal\Core\Render\RendererInterface;
 use Drupal\inline_entity_form\InlineEntityForm\EntityInlineEntityFormHandler;
 
 /**
@@ -221,7 +223,7 @@ function inline_entity_form_update_row_weights($element, FormStateInterface $for
   $ief_id = $element['#ief_id'];
   // Loop over the submitted delta values and update the weight of the entities
   // in the form state.
-  foreach (element_children($element['entities']) as $key) {
+  foreach (Element::children($element['entities']) as $key) {
     $form_state->set(['inline_entity_form', $ief_id, 'entities', $key, '_weight'], $element['entities'][$key]['delta']['#value']);
   }
 }
@@ -478,7 +480,7 @@ function inline_entity_form_close_child_forms($form, &$form_state) {
  */
 function inline_entity_form_close_all_forms($elements, FormStateInterface $form_state) {
   // Recurse through all children.
-  foreach (element_children($elements) as $key) {
+  foreach (Element::children($elements) as $key) {
     if (!empty($elements[$key])) {
       inline_entity_form_close_all_forms($elements[$key], $form_state);
     }
@@ -565,7 +567,7 @@ function theme_inline_entity_form_entity_table($variables) {
   ));
   // If one of the rows is in form context, disable tabledrag.
   $has_tabledrag = TRUE;
-  foreach (element_children($form) as $key) {
+  foreach (Element::children($form) as $key) {
     if (!empty($form[$key]['form'])) {
       $has_tabledrag = FALSE;
     }
@@ -591,7 +593,7 @@ function theme_inline_entity_form_entity_table($variables) {
 
   // Build an array of entity rows for the table.
   $rows = array();
-  foreach (element_children($form) as $key) {
+  foreach (Element::children($form) as $key) {
     $entity = $form[$key]['#entity'];
     // Many field formatters (such as the ones for files and images) need
     // certain data that might be missing on unsaved entities because the field
@@ -605,7 +607,7 @@ function theme_inline_entity_form_entity_table($variables) {
     $cells = array();
     if ($has_tabledrag) {
       $cells[] = array('data' => '', 'class' => array('ief-tabledrag-handle'));
-      $cells[] = drupal_render($form[$key]['delta']);
+      $cells[] = RendererInterface::render($form[$key]['delta']);
       $row_classes[] = 'draggable';
     }
     // Add a special class to rows that have a form underneath, to allow
@@ -621,14 +623,14 @@ function theme_inline_entity_form_entity_table($variables) {
     }
 
     // Add the buttons belonging to the "Operations" column.
-    $cells[] = drupal_render($form[$key]['actions']);
+    $cells[] = RendererInterface::render($form[$key]['actions']);
     // Create the row.
     $rows[] = array('data' => $cells, 'class' => $row_classes);
 
     // If the current entity array specifies a form, output it in the next row.
     if (!empty($form[$key]['form'])) {
       $row = array(
-        array('data' => drupal_render($form[$key]['form']), 'colspan' => count($fields) + 1),
+        array('data' => RendererInterface::render($form[$key]['form']), 'colspan' => count($fields) + 1),
       );
       $rows[] = array('data' => $row, 'class' => array('ief-row-form'), 'no_striping' => TRUE);
     }
@@ -663,7 +665,7 @@ function theme_inline_entity_form_entity_table($variables) {
       '#tabledrag' => $tabledrag,
     );
 
-    return drupal_render($table);
+    return RendererInterface::render($table);
   }
 }
 
@@ -685,7 +687,7 @@ function inline_entity_form_field_widget_error($element, $error) {
  */
 function inline_entity_form_pre_render_add_fieldset_markup($form) {
   $sort = array();
-  foreach (element_children($form) as $key) {
+  foreach (Element::children($form) as $key) {
     $element = $form[$key];
     // In our form builder functions, we added an arbitrary #fieldset property
     // to any element that belongs in a fieldset. If this form element has that

--- a/inline_entity_form.module
+++ b/inline_entity_form.module
@@ -13,7 +13,6 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
-use Drupal\Core\Render\RendererInterface;
 use Drupal\inline_entity_form\InlineEntityForm\EntityInlineEntityFormHandler;
 
 /**
@@ -557,6 +556,7 @@ function inline_entity_form_get_element($form, FormStateInterface $form_state) {
  *   Contains the form element data from $element['entities'].
  */
 function theme_inline_entity_form_entity_table($variables) {
+  $renderer = \Drupal::service('renderer');
   $form = $variables['form'];
   $entity_type = $form['#entity_type'];
   $fields = $form['#table_fields'];
@@ -607,7 +607,7 @@ function theme_inline_entity_form_entity_table($variables) {
     $cells = array();
     if ($has_tabledrag) {
       $cells[] = array('data' => '', 'class' => array('ief-tabledrag-handle'));
-      $cells[] = RendererInterface::render($form[$key]['delta']);
+      $cells[] = $renderer->render($form[$key]['delta']);
       $row_classes[] = 'draggable';
     }
     // Add a special class to rows that have a form underneath, to allow
@@ -623,14 +623,14 @@ function theme_inline_entity_form_entity_table($variables) {
     }
 
     // Add the buttons belonging to the "Operations" column.
-    $cells[] = RendererInterface::render($form[$key]['actions']);
+    $cells[] = $renderer->render($form[$key]['actions']);
     // Create the row.
     $rows[] = array('data' => $cells, 'class' => $row_classes);
 
     // If the current entity array specifies a form, output it in the next row.
     if (!empty($form[$key]['form'])) {
       $row = array(
-        array('data' => RendererInterface::render($form[$key]['form']), 'colspan' => count($fields) + 1),
+        array('data' => $renderer->render($form[$key]['form']), 'colspan' => count($fields) + 1),
       );
       $rows[] = array('data' => $row, 'class' => array('ief-row-form'), 'no_striping' => TRUE);
     }
@@ -665,7 +665,7 @@ function theme_inline_entity_form_entity_table($variables) {
       '#tabledrag' => $tabledrag,
     );
 
-    return RendererInterface::render($table);
+    return $renderer->render($table);
   }
 }
 


### PR DESCRIPTION
There is some deprecated functions like drupal_render and element_children, so replace them like defined in core comments.
